### PR TITLE
Adds S3 bucket terraform, and terraform ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,4 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 
+**/*terraform**

--- a/cloud-resources/main.tf
+++ b/cloud-resources/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+  access_key = var.access_key
+  secret_key = var.secret_key
+}
+
+resource "aws_vpc" "judgement_project" {}
+
+resource "aws_s3_bucket" "judgement_xml" {
+  bucket = "judgement_xml"
+  force_destroy = true
+}

--- a/cloud-resources/variables.tf
+++ b/cloud-resources/variables.tf
@@ -1,0 +1,7 @@
+variable "access_key" {
+  type = string
+}
+
+variable "secret_key" {
+  type = string
+}


### PR DESCRIPTION
Adds `/cloud-resources`, adds terraform for an s3 bucket along with basic provider configuration, adds sensitive terraform files to the `.gitignore`.

Closes #40 