### PR TITLE
Fix role prompt engineering

### DIFF
--- a/.github/workflows/deploy-ses-lambda.yml
+++ b/.github/workflows/deploy-ses-lambda.yml
@@ -37,4 +37,4 @@ jobs:
         docker tag judgment-reader-report-lambda ${REPORT_LAMBDA_ECR_URL}:latest
         docker push ${REPORT_LAMBDA_ECR_URL}:latest
         aws lambda update-function-code \
-          --function-name judgment-reader-report-lambda --image-uri ${REPORT_LAMBDA_ECR_URL}
+          --function-name judgment-reader-report --image-uri ${REPORT_LAMBDA_ECR_URL}:latest

--- a/deploy-ses-lambda.sh
+++ b/deploy-ses-lambda.sh
@@ -3,3 +3,5 @@ aws ecr get-login-password --region eu-west-2 | docker login --username AWS --pa
 docker build --platform linux/arm64 --provenance false -t judgment-reader-report-lambda ses_lambda/.
 docker tag judgment-reader-report-lambda ${REPORT_LAMBDA_ECR_URL}:latest
 docker push ${REPORT_LAMBDA_ECR_URL}:latest
+aws lambda update-function-code \
+          --function-name judgment-reader-report --image-uri ${REPORT_LAMBDA_ECR_URL}:latest

--- a/seed_data/prompt_engineering.py
+++ b/seed_data/prompt_engineering.py
@@ -64,7 +64,7 @@ def get_case_summary(model: str, client: OpenAI, case: str) -> dict:
     - judgment_description: a summary of the judgment
     - parties: A list of all parties involved in the case, with the following details for each party:
         - name: The name of the party.
-        - role: The role of the party.
+        - role: The role of the party, must be singular.
         - counsels: A list of counsel(s) for the party, with the following details for each counsel:
             - name: The name of the counsel (e.g., "William Bennett KC").
             - title: The title of the counsel (e.g., "KC", "QC", or none).


### PR DESCRIPTION
Now roles should all be singular, preventing respondent and respondents being separate roles.
Closes #222 .